### PR TITLE
remove no-return-assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
     'no-multiple-empty-lines': 0,
     'one-var': 0,
     'no-negated-condition': 0,
+    'no-return-assign': 0,
     radix: 0,
     'no-implicit-globals': 0,
     'one-var-declaration-per-line': 0,


### PR DESCRIPTION
Would be cool if we had a version of `no-return-assign` that just skipped over implicit returns (ie only error when `return` is used) but I don't think it's that important.
