### PR TITLE
locking eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/wix-private/eslint-config-wix#readme",
   "devDependencies": {
-    "eslint": "^2.9.0",
+    "eslint": "~2.10.0",
     "wnpm-ci": "*"
   },
   "publishConfig": {


### PR DESCRIPTION
If you uses 2.11.0 you will hit [this bug](https://github.com/babel/babel-eslint/issues/316)
