### PR TITLE
allow no-use-before-define

### DIFF
--- a/react-native.js
+++ b/react-native.js
@@ -39,6 +39,7 @@ module.exports = {
       'error',
       'tag-aligned'
     ],
+    'no-use-before-define': 0, //this breaks in react-native apps because of styles
     'react-native-wix/never-device-emitter-remove-all': 2
   },
   globals: {

--- a/test/eslint-config-wix.spec.js
+++ b/test/eslint-config-wix.spec.js
@@ -45,8 +45,8 @@ describe('wix eslint', () => {
       expect(() => exec('react-native', 'react-native/invalid-functions.js')).to.throw('Expected parentheses around arrow function argument  babel/arrow-parens');
     });
 
-    it('should fail for no use before define', () => {
-      expect(() => exec('react-native', 'react-native/no-use-before-define.js')).to.throw('error  \'a\' was used before it was defined  no-use-before-define');
+    it('should allow no use before define', () => {
+      exec('react-native', 'react-native/no-use-before-define.js');
     });
   });
 


### PR DESCRIPTION
this breaks all RN apps because `styles` get defined after their actually used
