### PR TITLE
updated to new eslint plugins and fixed broken rule as a result of using the old version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,19 +32,17 @@
     "registry": "http://repo.dev.wix/artifactory/api/npm/npm-local/"
   },
   "dependencies": {
-    "eslint-config-xo": "~0.14.0",
-    "eslint-config-xo-react": "~0.7.0",
-    "eslint-plugin-babel": "~3.2.0",
-    "eslint-plugin-react": "~5.0.1",
-    "babel-eslint": "latest",
-    "eslint-plugin-mocha": "~2.2.0",
+    "eslint-config-xo": "^0.16.0",
+    "eslint-config-xo-react": "^0.10.0",
+    "eslint-plugin-react": "^6.0.0",
+    "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-react-native-wix": "^1.0.0"
   },
   "devDependencies": {
-    "chai": "~3.5.0",
-    "eslint": "~2.9.0",
-    "mocha": "~2.5.3",
-    "mocha-env-reporter": "~1.0.2",
+    "chai": "^3.0.0",
+    "eslint": "^3.0.0",
+    "mocha": "^3.0.0",
+    "mocha-env-reporter": "^1.0.0",
     "wnpm-ci": "latest"
   },
   "peerDependencies": {

--- a/react-native.js
+++ b/react-native.js
@@ -1,7 +1,11 @@
 'use strict';
-var path = require('path');
+const path = require('path');
 
 module.exports = {
+  parserOptions: {
+    ecmaVersion: 2017,
+    sourceType: 'module'
+  },
   extends: [
     'xo/esnext',
     'xo-react/space',
@@ -11,10 +15,7 @@ module.exports = {
     'react-native-wix'
   ],
   rules: {
-    'react/prop-types': 0, //no prop validations
-    'react/jsx-handler-names': 0, // any prop name is OK
-    'arrow-parens': 0, //doesn't work with babel
-    'babel/arrow-parens': [ // ensure arrow parens
+    'arrow-parens': [
       'error',
       'always'
     ],
@@ -24,8 +25,8 @@ module.exports = {
         args: 'none'
       }
     ],
-    'generator-star-spacing': 0, // doesn't work with babel
-    'babel/generator-star-spacing': [ // spacing in async functions
+    'no-use-before-define': 0, //this breaks in react-native apps because of styles
+    'generator-star-spacing': [ // spacing in async functions
       'error',
       'after'
     ],
@@ -39,7 +40,9 @@ module.exports = {
       'error',
       'tag-aligned'
     ],
-    'no-use-before-define': 0, //this breaks in react-native apps because of styles
+    'react/prop-types': 0, //no prop validations
+    'react/jsx-handler-names': 0, // any prop name is OK
+    'react/forbid-component-props': 0, //no needed in react-native
     'react-native-wix/never-device-emitter-remove-all': 2
   },
   globals: {

--- a/test/eslint-config-wix.spec.js
+++ b/test/eslint-config-wix.spec.js
@@ -42,11 +42,21 @@ describe('wix eslint', () => {
     });
 
     it('should fail for invalid functions', () => {
-      expect(() => exec('react-native', 'react-native/invalid-functions.js')).to.throw('Expected parentheses around arrow function argument  babel/arrow-parens');
+      expect(() => exec('react-native', 'react-native/invalid-functions.js')).to.throw('Expected parentheses around arrow function argument  arrow-parens');
     });
 
     it('should allow no use before define', () => {
       exec('react-native', 'react-native/no-use-before-define.js');
+    });
+
+    it('fails on unused expressions', () => {
+      expect(() => exec('react-native', 'react-native/unused-expressions.js'))
+        .to
+        .throw('Expected an assignment or function call and instead saw an expression  no-unused-expressions');
+    });
+
+    it('allows dangling awaits', () => {
+      exec('react-native', 'react-native/dangling-awaits.js');
     });
   });
 

--- a/test/scripts/react-native/dangling-awaits.js
+++ b/test/scripts/react-native/dangling-awaits.js
@@ -1,0 +1,3 @@
+export async function foo() {
+  await new Promise((r) => r());
+}

--- a/test/scripts/react-native/no-use-before-define.js
+++ b/test/scripts/react-native/no-use-before-define.js
@@ -2,3 +2,5 @@
 a++;
 
 let a = 1;
+
+export default a;

--- a/test/scripts/react-native/unused-expressions.js
+++ b/test/scripts/react-native/unused-expressions.js
@@ -1,0 +1,3 @@
+export function bad(n) {
+  n + 1;
+}


### PR DESCRIPTION
This also enables us to remove our dependency on babel-plugin and babel-eslint, as eslint now supports es6 and es7 out of the box
