### PR TITLE
Loosen up the "jsx-closing-bracket-location" rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -18,6 +18,10 @@ module.exports = {
     'react/jsx-pascal-case': 0,
     'react/no-unused-prop-types': 0,
     'react/no-children-prop': 0,
+    'react/jsx-closing-bracket-location': ['error', {
+      nonEmpty: 'tag-aligned',
+      selfClosing: false
+    }],
     'react/forbid-component-props': 0
   }
 };


### PR DESCRIPTION
When upgrading to `eslint@4` it seems that there is a clash between `jsx-closing-bracket-location` from `eslint-plugin-react` to the `indent` rule from `eslint@4` default configuration.

Seems that there is a fix for that in [`eslint-config-xo-react`](https://github.com/xojs/eslint-config-xo-react/commit/de461183f87fec0c2a3acae267adf1bebc686255) that release on version `0.16.0` that requires `eslint-plugin-react` to be above version `7.6.1` which is breaking for our users. so as a compromise, just do this specific change so it won't break anyone.

read more:
https://github.com/eslint/eslint/issues/8425
https://github.com/yannickcr/eslint-plugin-react/issues/1247
https://github.com/eslint/eslint/issues/8594
