### PR TITLE
change jsx-no-bind

### DIFF
--- a/react-native.js
+++ b/react-native.js
@@ -33,10 +33,7 @@ module.exports = {
       'after'
     ],
     'react/jsx-no-bind': [ // bind not allowed in render
-      'error',
-      {
-        allowArrowFunctions: true
-      }
+      'warn'
     ],
     'react/jsx-closing-bracket-location': [
       'error',


### PR DESCRIPTION
Arrow functions are just as bad bind in render, I believe allowing them is no good. Changed from error to warning because it would most likely break half of one app builds