### PR TITLE
Bump version of babel-eslint to 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ module.exports = {
   },
   plugins: ['mocha', 'jasmine'],
   parser: 'babel-eslint',
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
   rules: {
     strict: 0,
     indent: [2, 2, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wix",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Shared eslint config for all Wix projects",
   "scripts": {
     "build": ":",
@@ -30,22 +30,22 @@
     "babel-eslint": "^10.0.0",
     "eslint-config-xo": "^0.16.0",
     "eslint-config-xo-react": "^0.10.0",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-jasmine": "^2.6.2",
-    "eslint-plugin-lodash": "^2.4.4",
-    "eslint-plugin-mocha": "^4.0.0",
-    "eslint-plugin-react": "^6.10.0",
+    "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-jasmine": "^4.1.1",
+    "eslint-plugin-lodash": "^7.1.0",
+    "eslint-plugin-mocha": "^7.0.1",
+    "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-native-wix": "^1.0.0",
     "eslint-plugin-wix-style-react": "^1.0.0"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
-    "eslint": "^3.0.0",
-    "mocha": "^3.0.0",
-    "mocha-env-reporter": "^1.0.0",
+    "chai": "^4.2.0",
+    "eslint": "^7.2.0",
+    "mocha": "^8.0.1",
+    "mocha-env-reporter": "^4.0.0",
     "wnpm-ci": "latest"
   },
   "peerDependencies": {
-    "eslint": ">=3.0.0"
+    "eslint": ">=7.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "babel-eslint": "^7.0.0",
+    "babel-eslint": "^10.0.0",
     "eslint-config-xo": "^0.16.0",
     "eslint-config-xo-react": "^0.10.0",
     "eslint-plugin-babel": "^3.3.0",

--- a/test/scripts/react-native/valid-functions.js
+++ b/test/scripts/react-native/valid-functions.js
@@ -10,7 +10,7 @@ async function zar(a) {
   return await new Promise((r) => r(a));
 }
 
-const goo = async(a) => {
+const goo = async (a) => {
   return await new Promise((r) => r(a));
 };
 


### PR DESCRIPTION
OneApp has some scripts that need babel-eslint 10+, but this package is bringing 7, and this is making us need to add babel-eslint to every one-app module instead of with the rest of our common dev depenencies.